### PR TITLE
Add cmake to path_suffixes

### DIFF
--- a/languages/cmake/config.toml
+++ b/languages/cmake/config.toml
@@ -1,6 +1,6 @@
 name = "CMake"
 grammar = "cmake"
-path_suffixes = ["CMakeLists.txt"]
+path_suffixes = ["CMakeLists.txt", "cmake"]
 line_comments = ["# "]
 autoclose_before = ";:.,=}])"
 brackets = [


### PR DESCRIPTION
The `cmake` suffix is commonly used for cmake files. The PR adds it to the path_suffixes.