### PR TITLE
Removing space between path_suffixes

### DIFF
--- a/languages/cmake/config.toml
+++ b/languages/cmake/config.toml
@@ -1,6 +1,6 @@
 name = "CMake"
 grammar = "cmake"
-path_suffixes = ["CMakeLists.txt", "cmake"]
+path_suffixes = ["CMakeLists.txt","cmake"]
 line_comments = ["# "]
 autoclose_before = ";:.,=}])"
 brackets = [


### PR DESCRIPTION
Removing the space between both values in `path_suffixes` will make sure that the LSP sees both `CMakeLists.txt` and `cmake` as suffixes. 
Before this fix only `CMakeLists.txt` would trigger the LSP. 